### PR TITLE
Update README with features and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,42 @@
 # Focus
 
-Simple C++ microservice using Crow and PostgreSQL.
+Simple C++ microservice using Crow and PostgreSQL for tracking tasks.
+
+## Features
+
+- **Health check** via `GET /healthz`.
+- **List tasks** with `GET /tasks`.
+- **Create tasks** using `POST /tasks` with `name`, `start_at` and `end_at` fields.
+- **Toggle or set completion** with `PATCH /tasks/<id>`.
+- **Delete tasks** using `DELETE /tasks/<id>`.
+
+Database connection parameters can be overridden using the `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASS` and `DB_NAME` environment variables. Defaults match the provided `docker-compose.yml` service.
+
+## Building
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+Run the unit tests:
+
+```bash
+ctest --test-dir build --output-on-failure
+```
 
 ## Running locally
 
-When not using `docker-compose`, set `DB_HOST` so the service knows where
-PostgreSQL is running:
+Start the service against a local PostgreSQL instance:
 
 ```bash
 DB_HOST=127.0.0.1 ./build/focus
 ```
 
-The default host is `db` which matches the service name in the provided
-`docker-compose.yml`.
+The default host is `db`, which matches the service name when running with `docker-compose`:
+
+```bash
+docker compose up --build
+```
+
+A smoke test script is provided in `scripts/smoke.sh` to exercise the API.


### PR DESCRIPTION
## Summary
- document API endpoints and environment variables
- add build and run instructions
- mention smoke test script

## Testing
- `cmake .. && make -j4` *(fails: could not run tests due to missing Postgres)*
- `ctest --output-on-failure` *(fails: connection to server at "127.0.0.1" failed)*

------
https://chatgpt.com/codex/tasks/task_e_687428e62e148323ae7cbe3a2bf0dd44